### PR TITLE
Add a default option to render license badge

### DIFF
--- a/test.md
+++ b/test.md
@@ -1,7 +1,7 @@
 
   # q
 
-  undefined
+  
 
   # Table of Contents
   1. [application description](#description)

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -1,5 +1,4 @@
-// TODO: Create a function that returns a license badge based on which license is passed in
-// If there is no license, return an empty string
+// renders chosen license badge 
 function renderLicenseBadge(license) {
   switch (license) {
     case 'MIT':
@@ -11,7 +10,7 @@ function renderLicenseBadge(license) {
     case 'Apache':
       return '[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)'
       break;
-    default: console.log('Im sorry something went wrong');
+    default: return '';
   }
 }
 


### PR DESCRIPTION
Changed the default option from a console log to a empty string that is rendered in the readme.